### PR TITLE
Don't panic when closing an unused handler.

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -40,11 +40,14 @@ func (h *Handler) openORCFile() error {
 }
 
 func (h *Handler) closeORCFile() error {
-	err := h.writer.Close()
-	if err != nil {
-		return err
+	// If we never call HandleLog then there'll be no writer.
+	if h.writer != nil {
+		err := h.writer.Close()
+		if err != nil {
+			return err
+		}
+		h.writer = nil
 	}
-	h.writer = nil
 	return nil
 }
 

--- a/handler_test.go
+++ b/handler_test.go
@@ -55,5 +55,15 @@ func TestHandleLog(t *testing.T) {
 	if msg != logMsg {
 		t.Errorf("Expected %q, got %q", logMsg, msg)
 	}
+}
 
+// If we never call HandleLog we won't have an ORC writer to hand,
+// this shouldn't cause a panic. Note this is testing a problem that
+// really occured.
+func TestCloseOnUnusedHandler(t *testing.T) {
+	handler := NewHandler("Path")
+	err := handler.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
 }


### PR DESCRIPTION
Because we don't create the ORC writer for the Handler until the first call to ```HandleLog```, we we're getting panics when we tried to call ```Close``` on that writer during rotation, if no attempt to log anything to the handler had been made.  This PR fixes that and adds a test case to cover this. 